### PR TITLE
Convert this contract from using main to individual entrypoints

### DIFF
--- a/nft-taquito/contract/NFTS_contract.mligo
+++ b/nft-taquito/contract/NFTS_contract.mligo
@@ -499,7 +499,7 @@ let transfer (txs : transfer list) (storage : nft_token_storage) : returnValue =
 
 (** Balance entrypoint *)
 [@entry]
-let balance (p : balance_of_param) (storage : nft_token_storage) : returnValue =
+let balance_of (p : balance_of_param) (storage : nft_token_storage) : returnValue =
     let op = get_balance (p, storage.ledger) in
     [op], storage
 

--- a/nft-taquito/contract/NFTS_contract.mligo
+++ b/nft-taquito/contract/NFTS_contract.mligo
@@ -512,12 +512,12 @@ let update_operators (updates : update_operator list) (storage : nft_token_stora
 
 (** Mint NFT entrypoint *)
 [@entry]
-let mint (p : mint_params)  (storage : nft_token_storage) : returnValue =
+let mint (p : mint_params) (storage : nft_token_storage) : returnValue =
     ([]: operation list), mint (p, storage)
 
 (** Burn NFT entrypoint *)
 [@entry]
-let burn (p : token_id)  (storage : nft_token_storage) : returnValue =
+let burn (p : token_id) (storage : nft_token_storage) : returnValue =
     ([]: operation list), burn (p, storage)
 
 (*


### PR DESCRIPTION
The way of using main to denote entrypoints will be deprecated. This is also easier to read. I've tested the mint and burn entrypoints and they seem to work.
