### PR TITLE
This function needs to be named transfer_nfts

### DIFF
--- a/nft-taquito/contract/NFTS_contract.mligo
+++ b/nft-taquito/contract/NFTS_contract.mligo
@@ -362,7 +362,7 @@ permissions or constraints are violated.
 @param txs transfers to be applied to the ledger
 @param validate_op function that validates of the tokens from the particular owner can be transferred. 
  *)
-let transfer (txs, validate_op, ops_storage, ledger, reverse_ledger
+let transfer_nfts (txs, validate_op, ops_storage, ledger, reverse_ledger
     : (transfer list) * operator_validator * operator_storage * ledger * reverse_ledger) : ledger * reverse_ledger =
   (* process individual transfer *)
   let make_transfer = (fun ((l, rv_l), tx : (ledger * reverse_ledger) * transfer) ->


### PR DESCRIPTION
It's called on L495 as `transfer_nfts` so this function needs to be named `transfer_nfts` to avoid conflict with the `transfer` entrypoint.

I deployed the contract here and tested the transfer entrypoint and it works:
https://better-call.dev/ghostnet/KT1EK7QVHcLPwxey1FdGrrNtsnP9dLgBtYtY/operations

 Fixes https://github.com/trilitech/tutorial-applications/issues/6.