### PR TITLE
migrate bank-tutorial/package.json and migrate create-nfts tutorial to beacon

### DIFF
--- a/bank-tutorial/package-lock.json
+++ b/bank-tutorial/package-lock.json
@@ -8,9 +8,9 @@
       "name": "bank-tutorial",
       "version": "0.0.0",
       "dependencies": {
-        "@airgap/beacon-types": "^4.6.1",
         "@taquito/beacon-wallet": "^23.0.1",
-        "@taquito/taquito": "^23.0.1"
+        "@taquito/taquito": "^23.0.1",
+        "@tezos-x/octez.connect-types": "^4.6.1"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.0",
@@ -1633,6 +1633,15 @@
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^5.0.0"
+      }
+    },
+    "node_modules/@tezos-x/octez.connect-types": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@tezos-x/octez.connect-types/-/octez.connect-types-4.8.3.tgz",
+      "integrity": "sha512-/ToHY8BJTwK1XkCzJyAFn8pzXW6udV44GlTnncatsol02J3wk9JsaYB367Wmed4u4fpP7Z6KaBTlTK9DueLPRQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/chrome": "0.0.315"
       }
     },
     "node_modules/@types/bs58check": {

--- a/bank-tutorial/package.json
+++ b/bank-tutorial/package.json
@@ -17,8 +17,8 @@
     "vite-compatible-readable-stream": "^3.6.1"
   },
   "dependencies": {
-    "@tezos-x/octez.connect-types": "^4.6.1",
-    "@taquito/beacon-wallet": "^23.0.1",
-    "@taquito/taquito": "^23.0.1"
+    "@tezos-x/octez.connect-types": "^4.8.3",
+    "@taquito/beacon-wallet": "^24.2.0",
+    "@taquito/taquito": "^24.2.0"
   }
 }

--- a/bank-tutorial/package.json
+++ b/bank-tutorial/package.json
@@ -17,7 +17,7 @@
     "vite-compatible-readable-stream": "^3.6.1"
   },
   "dependencies": {
-    "@airgap/beacon-types": "^4.6.1",
+    "@tezos-x/octez.connect-types": "^4.6.1",
     "@taquito/beacon-wallet": "^23.0.1",
     "@taquito/taquito": "^23.0.1"
   }

--- a/create-nfts/part-2/package-lock.json
+++ b/create-nfts/part-2/package-lock.json
@@ -8,10 +8,10 @@
       "name": "create-nfts",
       "version": "0.0.0",
       "dependencies": {
-        "@taquito/beacon-wallet": "^24.0.1",
-        "@taquito/taquito": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
-        "@tezos-x/octez.connect-types": "^4.7.0"
+        "@taquito/beacon-wallet": "^24.2.0",
+        "@taquito/taquito": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
+        "@tezos-x/octez.connect-types": "^4.8.3"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
@@ -22,14 +22,23 @@
         "vite-compatible-readable-stream": "^3.6.1"
       }
     },
-    "node_modules/@airgap/beacon-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-4.7.0.tgz",
-      "integrity": "sha512-RyPf6KaJcVgWbzef6CvAv5PbkhuF2BDMpkToXliYU0mXibUjkbGJL0bXwEJd2l0jlsxjnlXaE/V78MXhDi8o1Q==",
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@ecadlabs/beacon-core": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-uXN+XG665fGHzbWiUp0mSxnixo+JgEFrKCC9dzTEw5utkAfnrnB2s70eN1y9420ab7D0LJb3iM6TMtNMDmmy+Q==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "@stablelib/ed25519": "^2.0.2",
         "@stablelib/nacl": "^2.0.1",
         "@stablelib/utf8": "^2.0.1",
@@ -38,84 +47,84 @@
         "bs58check": "4.0.0"
       }
     },
-    "node_modules/@airgap/beacon-dapp": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-4.7.0.tgz",
-      "integrity": "sha512-tXMDrvzAg3kXPF3p2FpwzHgnIheG8Ce9CJgZsMD8piY9YTxELrZp1V2nStnX/bwTrhqHsszKn+knJdLv6+PvKw==",
+    "node_modules/@ecadlabs/beacon-dapp": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-KKKu5YQmUzijJAJiVMmHik5mDRBwWkomsOstSkasDUQqIjStg2j2szN4v3CBRDeGihSu9OOICv390+qaen/iEg==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-transport-matrix": "4.7.0",
-        "@airgap/beacon-transport-postmessage": "4.7.0",
-        "@airgap/beacon-transport-walletconnect": "4.7.0",
-        "@airgap/beacon-ui": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-ui": "4.8.1-ecad.2",
         "broadcast-channel": "^7.1.0"
       }
     },
-    "node_modules/@airgap/beacon-transport-matrix": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-4.7.0.tgz",
-      "integrity": "sha512-22o6bluMwePg+ekQD10HD9LNikAiMv3UNzouzlj4mFZgRn7BVFSyuwMQvFQ6JnsG8H7zvNT2+hlwrYfGLpaSbw==",
+    "node_modules/@ecadlabs/beacon-transport-matrix": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-deztRLczTYx+pHJrSH+G1HtrjJdAOLww7tIyq0IA+OIhTqf5oa4DwA9ULYaeXTqIXVXWmfuUL64mBY/vgEDYqQ==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "axios": "^1.8.4"
       }
     },
-    "node_modules/@airgap/beacon-transport-postmessage": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-4.7.0.tgz",
-      "integrity": "sha512-3+qLeeBEmIm74XcG6xYnxnjOf4GwvLGB89DgdjUB/Qovw0hvFtMsxomh/U52q5b4vb/fr8Rd4EmC1BGYFL9cNQ==",
+    "node_modules/@ecadlabs/beacon-transport-postmessage": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-HjJiYTy+c2AieNXpNRoHqlmqiDGnmEtErecKNZVl6ahaKwKUi3kAtb84S55h4GJv+X8Lez0iFRP7lTtO4P3Fvw==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0"
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2"
       }
     },
-    "node_modules/@airgap/beacon-transport-walletconnect": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.7.0.tgz",
-      "integrity": "sha512-mwfnQ+rplc9f0I0z2x86tPA2gLgTc17Sc+xP9vTsR0niExntH9K7+U4QxPCgGav/plnA5ubzi/owLE+FaBEs4Q==",
+    "node_modules/@ecadlabs/beacon-transport-walletconnect": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-5FoAqWlSkQBD07EMPFj2oqFoYHCoOIgHqRewNOPwrseJQzPk+gV+2tmczOfco10IF/h73ildLVZ7NeBifhM3fw==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "@walletconnect/sign-client": "2.18.0",
         "elliptic": "^6.6.1"
       }
     },
-    "node_modules/@airgap/beacon-types": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-4.7.0.tgz",
-      "integrity": "sha512-J6z+WBnJhTL8HVyW3cXL3LCOIcxo/rzBPSufsvIITuUTfgCnQE4CR6p1TIyJmaXbolorug/7jtobMyTIXUK04g==",
+    "node_modules/@ecadlabs/beacon-types": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-dmONM1TOQQ11ZWQEtmDSgXC428O7CC4ayZQWR8h/oA+bSY7mdcMZU+yijEEuk0SL7w97q7OMcLkCYgwCtsCe+w==",
       "license": "ISC",
       "dependencies": {
         "@types/chrome": "0.0.315"
       }
     },
-    "node_modules/@airgap/beacon-ui": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-4.7.0.tgz",
-      "integrity": "sha512-6R5teYH6oEGxNSNjs+HfFWryUxqoeajHJ+l55FSXYCzQlKBUpqz2cG7ZIzsr83N1bvARc4RJ8j2FLutYvCYttA==",
+    "node_modules/@ecadlabs/beacon-ui": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-K3W2mDkAswBz8SnYEi4tnzlQE79v0TZvntmq/zVaHbskYPIF0QKx+v62qgSOy3TmRK0upqLwyJ2lhu4A6VnbMA==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-transport-postmessage": "4.7.0",
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "@walletconnect/utils": "2.18.0",
         "qrcode-svg": "^1.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       }
     },
-    "node_modules/@airgap/beacon-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-4.7.0.tgz",
-      "integrity": "sha512-QIE927Q55yuPVXoKfoabPJm2/lpbgSHAaXPpvjjyfeEnXbs5hMsTVo5AyMkQFEBRalL1UIchpPB2/+iJ5YisEg==",
+    "node_modules/@ecadlabs/beacon-utils": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-SyO3O8+XY8B3JHa6E8+erihScz0jFwsdXlwSACdxBmODuW7HCo/b9AgOcelaXi1s/6qTsjk5/2q56FYOMYmgHQ==",
       "license": "ISC",
       "dependencies": {
         "@stablelib/ed25519": "^2.0.2",
@@ -123,15 +132,6 @@
         "@stablelib/random": "^2.0.1",
         "@stablelib/utf8": "^2.0.1",
         "bs58check": "4.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/@stablelib/utf8": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-2.0.1.tgz",
-      "integrity": "sha512-7+C2Iap42fbLyoKMaEIIDSb1TrcQVo+lGDItYAwb2JoAJr7QffyuDnbtvV/qzTyokOIMBrJgT+Rpsp1bPR8SjA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-2.1.0.tgz",
+      "integrity": "sha512-peZgjgrPYOvjbJcVp91yYQLocr/qw5zcLsQBL+vH3D/d0IS+Cvcsbvlu+LLEcG8sVbkWMxr0ZABhY/0t3JMh0w==",
       "license": "MIT"
     },
     "node_modules/@stablelib/wipe": {
@@ -1507,14 +1507,15 @@
       }
     },
     "node_modules/@taquito/beacon-wallet": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-24.0.1.tgz",
-      "integrity": "sha512-4Of+A0ZF4jyrjSI7RWItBH6crhaowN1WWuAEHT535bNrn5Pj+dHVEhYl4T3XMhvmjOurStkdnG+TV8h9gDe1Zg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-24.2.0.tgz",
+      "integrity": "sha512-s9nCv30nUY/3Af+UFSu2vdNIhNIY+dwRvzZIH3X/k1oI4Jo2P3rRWiPyvSWKQs+eaCxHe37QsZsLEZgDmAByng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@airgap/beacon-dapp": "^4.6.4",
-        "@taquito/core": "^24.0.1",
-        "@taquito/taquito": "^24.0.1",
+        "@ecadlabs/beacon-dapp": "^4.8.1-ecad",
+        "@ecadlabs/beacon-types": "^4.8.1-ecad",
+        "@taquito/core": "^24.2.0",
+        "@taquito/taquito": "^24.2.0",
         "crypto-browserify": "^3.12.1",
         "util": "^0.12.5"
       },
@@ -1523,9 +1524,9 @@
       }
     },
     "node_modules/@taquito/core": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/core/-/core-24.0.1.tgz",
-      "integrity": "sha512-WnfWOmwOJ1KNkdGYa6DenVzSOVfmv7kHUiF+9Z9VtxmxOTPJf9mX/iBSmIeCuSJsOIkXJkswox5CTvrsnfXDcw==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/core/-/core-24.2.0.tgz",
+      "integrity": "sha512-Yo+lWWn1NrSawDDoRwgumnSTto8y9Z4EBz9pbURdl+KczGSwyEDXLTR6m7jQ1Hh1XhRYScadlyDr+AH95CdMeA==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-stringify-safe": "^5.0.1"
@@ -1535,12 +1536,12 @@
       }
     },
     "node_modules/@taquito/http-utils": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-24.0.1.tgz",
-      "integrity": "sha512-oNyxXtuonKKCnYy/eT9uzjN46i1KbsI2iJB+nf6FFGb4lJFHrXDiL1Tg1aITpv5Jy/aQmuCveh7fBFkfS4ekhQ==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-24.2.0.tgz",
+      "integrity": "sha512-+QXvH4BQxwvBNO0jPL4viICfH8YlJlsWVnBl7H5IFXiH9CxypXWgi4LS+awsZYCBf2yqJ/5irT4yS1KtnYjR3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
+        "@taquito/core": "^24.2.0",
         "node-fetch": "^2.7.0"
       },
       "engines": {
@@ -1548,13 +1549,13 @@
       }
     },
     "node_modules/@taquito/local-forging": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-24.0.1.tgz",
-      "integrity": "sha512-GY+584pVcohF9kFHqA+grX8/b8fYbMcyaXiCA/QLA0HJSImeDX3U/tOvZhAmAZhn1X6OcThHvC2PrTtqCrsvgA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-24.2.0.tgz",
+      "integrity": "sha512-BHwFpbiTvLg+qsDSLaFvLHlqokf2HGpFb/No85RcYvzuDAK7cSxJFpRdnn1U/GFIo8eXUAd2Rlo1VlStrS1rxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "fast-text-encoding": "^1.0.6",
         "whatwg-url": "^15.1.0"
@@ -1564,27 +1565,27 @@
       }
     },
     "node_modules/@taquito/michel-codec": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-24.0.1.tgz",
-      "integrity": "sha512-iPw2qQL+i8xWu1t843ztejMPHO3nJ4mY7LOBuoaSfelfGyjl5SQjYHxwI0DS3ph/KhXlfm95HcYwEILRqGhisg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-24.2.0.tgz",
+      "integrity": "sha512-+pTGzEHjWY21ybcUF9qutnYedjqJGqr5vuxpnTeajrNiWymHDHOb0vSlhwVrEPcGZTydMxN7Kth6zRDxwqxW8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1"
+        "@taquito/core": "^24.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@taquito/michelson-encoder": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-24.0.1.tgz",
-      "integrity": "sha512-c5hkyZegUo9l74Iia38oxumO8Oh3zbWZz2Bjvx0529N3bDeXu76EXeVwViNL8v/Ug7RVtGj07tvcUmFyErmQ9g==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-24.2.0.tgz",
+      "integrity": "sha512-6/gViqi5HEx89BHvo9hxiZvrIbA4gnRlg//vZeRwsWwm8smKD/JXR4l/5FKQZwAeHDzeduNN668S5gqp8ayM+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/rpc": "^24.0.1",
-        "@taquito/signer": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/rpc": "^24.2.0",
+        "@taquito/signer": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "fast-json-stable-stringify": "^2.1.0"
       },
@@ -1593,14 +1594,14 @@
       }
     },
     "node_modules/@taquito/rpc": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-24.0.1.tgz",
-      "integrity": "sha512-6NRgixtZKh6w2ivsQtFkPgYzYYQCtoXyI2ph7WMKbrKERcGxzuPM12MZb1Jwx8EepOyWqDwstSH1uH3XAWdjaA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-24.2.0.tgz",
+      "integrity": "sha512-KiPO6/Sk3x+fuDnlJwgPx1K+W7QqdbbC/QdZvI1vdSnvnImlwvre3ecA1ssL15UlEjH/iFfT2B2+YM2eYcByig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/http-utils": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/http-utils": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "whatwg-url": "^15.1.0"
       },
@@ -1609,9 +1610,9 @@
       }
     },
     "node_modules/@taquito/signer": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-24.0.1.tgz",
-      "integrity": "sha512-8khsDYeI/ByatuuAbD7gIhCGLpouU5O/0wGKRuvHcwXxgXBD8EKtY/MK+5QIu8yesNdokpiQc6m4W2YUh14kng==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-24.2.0.tgz",
+      "integrity": "sha512-wInvqnAlYMIj2FUL2YYEYSE1MRvtMesL964+4ZOI7rR9ugK5ZeEYsOab2UQzLvfwsk2z63Cc1sgxwV1HCzOGfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.7",
@@ -1621,8 +1622,8 @@
         "@stablelib/nacl": "^1.0.4",
         "@stablelib/pbkdf2": "^1.0.1",
         "@stablelib/sha512": "^1.0.1",
-        "@taquito/core": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "@types/bn.js": "^5.1.5",
         "bip39": "3.1.0",
         "bn.js": "^5.2.2",
@@ -1781,20 +1782,20 @@
       }
     },
     "node_modules/@taquito/taquito": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-24.0.1.tgz",
-      "integrity": "sha512-ltGPi+n7Buws5du7bb8jHq13LKsnzfWQCyuKDg0rgXApfESkxLkYap6hZDKeKdz+95YFCMPW+gZvRfEZ847Xlw==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-24.2.0.tgz",
+      "integrity": "sha512-gHRQDEq98+HASNF5gd2yHpi8qW7IXSakmpIh1oxbj8KIE99Tgm64k1ViPSsdnT/socw4e743AQNddfPAemZCeQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/http-utils": "^24.0.1",
-        "@taquito/local-forging": "^24.0.1",
-        "@taquito/michel-codec": "^24.0.1",
-        "@taquito/michelson-encoder": "^24.0.1",
-        "@taquito/rpc": "^24.0.1",
-        "@taquito/signer": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/http-utils": "^24.2.0",
+        "@taquito/local-forging": "^24.2.0",
+        "@taquito/michel-codec": "^24.2.0",
+        "@taquito/michelson-encoder": "^24.2.0",
+        "@taquito/rpc": "^24.2.0",
+        "@taquito/signer": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "rxjs": "^7.8.2"
       },
@@ -1803,15 +1804,15 @@
       }
     },
     "node_modules/@taquito/utils": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-24.0.1.tgz",
-      "integrity": "sha512-YNRoCjps42vCMkW9oTpE7CnrvUPoSOWy7L49IAueRGcJT/pgyEZZT6BLEc2ahP+jAqFJK8lBpKV9qhL6NTbXWg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-24.2.0.tgz",
+      "integrity": "sha512-/X10WVGe7Ztx8+/FCLu5wA6zVx09Py4/wnOCo0lFJxsMKrUmBCsGeBZYb948FbX8CvLidgGy2kQTntS9wFQAsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.7",
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.3",
-        "@taquito/core": "^24.0.1",
+        "@taquito/core": "^24.2.0",
         "@types/bs58check": "^2.1.2",
         "bignumber.js": "^9.1.2",
         "blakejs": "^1.2.1",
@@ -2320,9 +2321,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -2389,13 +2390,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3272,9 +3273,9 @@
       }
     },
     "node_modules/h3": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
-      "integrity": "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.10.tgz",
+      "integrity": "sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
@@ -3543,9 +3544,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4039,24 +4040,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.4"
       }
     },
     "node_modules/readable-stream": {

--- a/create-nfts/part-2/package-lock.json
+++ b/create-nfts/part-2/package-lock.json
@@ -8,10 +8,10 @@
       "name": "create-nfts",
       "version": "0.0.0",
       "dependencies": {
-        "@airgap/beacon-types": "^4.7.0",
         "@taquito/beacon-wallet": "^24.0.1",
         "@taquito/taquito": "^24.0.1",
-        "@taquito/utils": "^24.0.1"
+        "@taquito/utils": "^24.0.1",
+        "@tezos-x/octez.connect-types": "^4.7.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
@@ -1916,6 +1916,15 @@
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^5.0.0"
+      }
+    },
+    "node_modules/@tezos-x/octez.connect-types": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@tezos-x/octez.connect-types/-/octez.connect-types-4.8.3.tgz",
+      "integrity": "sha512-/ToHY8BJTwK1XkCzJyAFn8pzXW6udV44GlTnncatsol02J3wk9JsaYB367Wmed4u4fpP7Z6KaBTlTK9DueLPRQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/chrome": "0.0.315"
       }
     },
     "node_modules/@types/bn.js": {

--- a/create-nfts/part-2/package.json
+++ b/create-nfts/part-2/package.json
@@ -17,7 +17,7 @@
     "vite-compatible-readable-stream": "^3.6.1"
   },
   "dependencies": {
-    "@airgap/beacon-types": "^4.7.0",
+    "@tezos-x/octez.connect-types": "^4.7.0",
     "@taquito/beacon-wallet": "^24.0.1",
     "@taquito/taquito": "^24.0.1",
     "@taquito/utils": "^24.0.1"

--- a/create-nfts/part-2/package.json
+++ b/create-nfts/part-2/package.json
@@ -17,9 +17,9 @@
     "vite-compatible-readable-stream": "^3.6.1"
   },
   "dependencies": {
-    "@tezos-x/octez.connect-types": "^4.7.0",
-    "@taquito/beacon-wallet": "^24.0.1",
-    "@taquito/taquito": "^24.0.1",
-    "@taquito/utils": "^24.0.1"
+    "@tezos-x/octez.connect-types": "^4.8.3",
+    "@taquito/beacon-wallet": "^24.2.0",
+    "@taquito/taquito": "^24.2.0",
+    "@taquito/utils": "^24.2.0"
   }
 }

--- a/create-nfts/part-2/src/App.svelte
+++ b/create-nfts/part-2/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { BeaconWallet } from "@taquito/beacon-wallet";
-  import { NetworkType } from "@airgap/beacon-types";
+  import { NetworkType } from "@tezos-x/octez.connect-types";
   import { TezosToolkit, MichelsonMap } from "@taquito/taquito";
   import { stringToBytes } from "@taquito/utils";
 

--- a/create-nfts/part-2/vite.config.js
+++ b/create-nfts/part-2/vite.config.js
@@ -21,9 +21,9 @@ return defineConfig({
     },
   resolve: {
     alias: {
-     "@airgap/beacon-types": path.resolve(
+     "@tezos-x/octez.connect-types": path.resolve(
        path.resolve(),
-       `./node_modules/@airgap/beacon-types/dist/${
+       `./node_modules/@tezos-x/octez.connect-types/dist/${
        isBuild ? "esm" : "cjs"
        }/index.js`
       ),

--- a/create-nfts/part-3/package-lock.json
+++ b/create-nfts/part-3/package-lock.json
@@ -8,10 +8,10 @@
       "name": "create-nfts",
       "version": "0.0.0",
       "dependencies": {
-        "@taquito/beacon-wallet": "^24.0.1",
-        "@taquito/taquito": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
-        "@tezos-x/octez.connect-types": "^4.7.0"
+        "@taquito/beacon-wallet": "^24.2.0",
+        "@taquito/taquito": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
+        "@tezos-x/octez.connect-types": "^4.8.3"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
@@ -22,14 +22,23 @@
         "vite-compatible-readable-stream": "^3.6.1"
       }
     },
-    "node_modules/@airgap/beacon-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-4.7.0.tgz",
-      "integrity": "sha512-RyPf6KaJcVgWbzef6CvAv5PbkhuF2BDMpkToXliYU0mXibUjkbGJL0bXwEJd2l0jlsxjnlXaE/V78MXhDi8o1Q==",
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@ecadlabs/beacon-core": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-uXN+XG665fGHzbWiUp0mSxnixo+JgEFrKCC9dzTEw5utkAfnrnB2s70eN1y9420ab7D0LJb3iM6TMtNMDmmy+Q==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "@stablelib/ed25519": "^2.0.2",
         "@stablelib/nacl": "^2.0.1",
         "@stablelib/utf8": "^2.0.1",
@@ -38,84 +47,84 @@
         "bs58check": "4.0.0"
       }
     },
-    "node_modules/@airgap/beacon-dapp": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-4.7.0.tgz",
-      "integrity": "sha512-tXMDrvzAg3kXPF3p2FpwzHgnIheG8Ce9CJgZsMD8piY9YTxELrZp1V2nStnX/bwTrhqHsszKn+knJdLv6+PvKw==",
+    "node_modules/@ecadlabs/beacon-dapp": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-KKKu5YQmUzijJAJiVMmHik5mDRBwWkomsOstSkasDUQqIjStg2j2szN4v3CBRDeGihSu9OOICv390+qaen/iEg==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-transport-matrix": "4.7.0",
-        "@airgap/beacon-transport-postmessage": "4.7.0",
-        "@airgap/beacon-transport-walletconnect": "4.7.0",
-        "@airgap/beacon-ui": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-ui": "4.8.1-ecad.2",
         "broadcast-channel": "^7.1.0"
       }
     },
-    "node_modules/@airgap/beacon-transport-matrix": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-4.7.0.tgz",
-      "integrity": "sha512-22o6bluMwePg+ekQD10HD9LNikAiMv3UNzouzlj4mFZgRn7BVFSyuwMQvFQ6JnsG8H7zvNT2+hlwrYfGLpaSbw==",
+    "node_modules/@ecadlabs/beacon-transport-matrix": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-deztRLczTYx+pHJrSH+G1HtrjJdAOLww7tIyq0IA+OIhTqf5oa4DwA9ULYaeXTqIXVXWmfuUL64mBY/vgEDYqQ==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "axios": "^1.8.4"
       }
     },
-    "node_modules/@airgap/beacon-transport-postmessage": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-4.7.0.tgz",
-      "integrity": "sha512-3+qLeeBEmIm74XcG6xYnxnjOf4GwvLGB89DgdjUB/Qovw0hvFtMsxomh/U52q5b4vb/fr8Rd4EmC1BGYFL9cNQ==",
+    "node_modules/@ecadlabs/beacon-transport-postmessage": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-HjJiYTy+c2AieNXpNRoHqlmqiDGnmEtErecKNZVl6ahaKwKUi3kAtb84S55h4GJv+X8Lez0iFRP7lTtO4P3Fvw==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0"
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2"
       }
     },
-    "node_modules/@airgap/beacon-transport-walletconnect": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.7.0.tgz",
-      "integrity": "sha512-mwfnQ+rplc9f0I0z2x86tPA2gLgTc17Sc+xP9vTsR0niExntH9K7+U4QxPCgGav/plnA5ubzi/owLE+FaBEs4Q==",
+    "node_modules/@ecadlabs/beacon-transport-walletconnect": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-5FoAqWlSkQBD07EMPFj2oqFoYHCoOIgHqRewNOPwrseJQzPk+gV+2tmczOfco10IF/h73ildLVZ7NeBifhM3fw==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "@walletconnect/sign-client": "2.18.0",
         "elliptic": "^6.6.1"
       }
     },
-    "node_modules/@airgap/beacon-types": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-4.7.0.tgz",
-      "integrity": "sha512-J6z+WBnJhTL8HVyW3cXL3LCOIcxo/rzBPSufsvIITuUTfgCnQE4CR6p1TIyJmaXbolorug/7jtobMyTIXUK04g==",
+    "node_modules/@ecadlabs/beacon-types": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-dmONM1TOQQ11ZWQEtmDSgXC428O7CC4ayZQWR8h/oA+bSY7mdcMZU+yijEEuk0SL7w97q7OMcLkCYgwCtsCe+w==",
       "license": "ISC",
       "dependencies": {
         "@types/chrome": "0.0.315"
       }
     },
-    "node_modules/@airgap/beacon-ui": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-4.7.0.tgz",
-      "integrity": "sha512-6R5teYH6oEGxNSNjs+HfFWryUxqoeajHJ+l55FSXYCzQlKBUpqz2cG7ZIzsr83N1bvARc4RJ8j2FLutYvCYttA==",
+    "node_modules/@ecadlabs/beacon-ui": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-K3W2mDkAswBz8SnYEi4tnzlQE79v0TZvntmq/zVaHbskYPIF0QKx+v62qgSOy3TmRK0upqLwyJ2lhu4A6VnbMA==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-transport-postmessage": "4.7.0",
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "@walletconnect/utils": "2.18.0",
         "qrcode-svg": "^1.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       }
     },
-    "node_modules/@airgap/beacon-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-4.7.0.tgz",
-      "integrity": "sha512-QIE927Q55yuPVXoKfoabPJm2/lpbgSHAaXPpvjjyfeEnXbs5hMsTVo5AyMkQFEBRalL1UIchpPB2/+iJ5YisEg==",
+    "node_modules/@ecadlabs/beacon-utils": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-SyO3O8+XY8B3JHa6E8+erihScz0jFwsdXlwSACdxBmODuW7HCo/b9AgOcelaXi1s/6qTsjk5/2q56FYOMYmgHQ==",
       "license": "ISC",
       "dependencies": {
         "@stablelib/ed25519": "^2.0.2",
@@ -123,15 +132,6 @@
         "@stablelib/random": "^2.0.1",
         "@stablelib/utf8": "^2.0.1",
         "bs58check": "4.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/@stablelib/utf8": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-2.0.1.tgz",
-      "integrity": "sha512-7+C2Iap42fbLyoKMaEIIDSb1TrcQVo+lGDItYAwb2JoAJr7QffyuDnbtvV/qzTyokOIMBrJgT+Rpsp1bPR8SjA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-2.1.0.tgz",
+      "integrity": "sha512-peZgjgrPYOvjbJcVp91yYQLocr/qw5zcLsQBL+vH3D/d0IS+Cvcsbvlu+LLEcG8sVbkWMxr0ZABhY/0t3JMh0w==",
       "license": "MIT"
     },
     "node_modules/@stablelib/wipe": {
@@ -1507,14 +1507,15 @@
       }
     },
     "node_modules/@taquito/beacon-wallet": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-24.0.1.tgz",
-      "integrity": "sha512-4Of+A0ZF4jyrjSI7RWItBH6crhaowN1WWuAEHT535bNrn5Pj+dHVEhYl4T3XMhvmjOurStkdnG+TV8h9gDe1Zg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-24.2.0.tgz",
+      "integrity": "sha512-s9nCv30nUY/3Af+UFSu2vdNIhNIY+dwRvzZIH3X/k1oI4Jo2P3rRWiPyvSWKQs+eaCxHe37QsZsLEZgDmAByng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@airgap/beacon-dapp": "^4.6.4",
-        "@taquito/core": "^24.0.1",
-        "@taquito/taquito": "^24.0.1",
+        "@ecadlabs/beacon-dapp": "^4.8.1-ecad",
+        "@ecadlabs/beacon-types": "^4.8.1-ecad",
+        "@taquito/core": "^24.2.0",
+        "@taquito/taquito": "^24.2.0",
         "crypto-browserify": "^3.12.1",
         "util": "^0.12.5"
       },
@@ -1523,9 +1524,9 @@
       }
     },
     "node_modules/@taquito/core": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/core/-/core-24.0.1.tgz",
-      "integrity": "sha512-WnfWOmwOJ1KNkdGYa6DenVzSOVfmv7kHUiF+9Z9VtxmxOTPJf9mX/iBSmIeCuSJsOIkXJkswox5CTvrsnfXDcw==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/core/-/core-24.2.0.tgz",
+      "integrity": "sha512-Yo+lWWn1NrSawDDoRwgumnSTto8y9Z4EBz9pbURdl+KczGSwyEDXLTR6m7jQ1Hh1XhRYScadlyDr+AH95CdMeA==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-stringify-safe": "^5.0.1"
@@ -1535,12 +1536,12 @@
       }
     },
     "node_modules/@taquito/http-utils": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-24.0.1.tgz",
-      "integrity": "sha512-oNyxXtuonKKCnYy/eT9uzjN46i1KbsI2iJB+nf6FFGb4lJFHrXDiL1Tg1aITpv5Jy/aQmuCveh7fBFkfS4ekhQ==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-24.2.0.tgz",
+      "integrity": "sha512-+QXvH4BQxwvBNO0jPL4viICfH8YlJlsWVnBl7H5IFXiH9CxypXWgi4LS+awsZYCBf2yqJ/5irT4yS1KtnYjR3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
+        "@taquito/core": "^24.2.0",
         "node-fetch": "^2.7.0"
       },
       "engines": {
@@ -1548,13 +1549,13 @@
       }
     },
     "node_modules/@taquito/local-forging": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-24.0.1.tgz",
-      "integrity": "sha512-GY+584pVcohF9kFHqA+grX8/b8fYbMcyaXiCA/QLA0HJSImeDX3U/tOvZhAmAZhn1X6OcThHvC2PrTtqCrsvgA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-24.2.0.tgz",
+      "integrity": "sha512-BHwFpbiTvLg+qsDSLaFvLHlqokf2HGpFb/No85RcYvzuDAK7cSxJFpRdnn1U/GFIo8eXUAd2Rlo1VlStrS1rxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "fast-text-encoding": "^1.0.6",
         "whatwg-url": "^15.1.0"
@@ -1564,27 +1565,27 @@
       }
     },
     "node_modules/@taquito/michel-codec": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-24.0.1.tgz",
-      "integrity": "sha512-iPw2qQL+i8xWu1t843ztejMPHO3nJ4mY7LOBuoaSfelfGyjl5SQjYHxwI0DS3ph/KhXlfm95HcYwEILRqGhisg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-24.2.0.tgz",
+      "integrity": "sha512-+pTGzEHjWY21ybcUF9qutnYedjqJGqr5vuxpnTeajrNiWymHDHOb0vSlhwVrEPcGZTydMxN7Kth6zRDxwqxW8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1"
+        "@taquito/core": "^24.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@taquito/michelson-encoder": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-24.0.1.tgz",
-      "integrity": "sha512-c5hkyZegUo9l74Iia38oxumO8Oh3zbWZz2Bjvx0529N3bDeXu76EXeVwViNL8v/Ug7RVtGj07tvcUmFyErmQ9g==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-24.2.0.tgz",
+      "integrity": "sha512-6/gViqi5HEx89BHvo9hxiZvrIbA4gnRlg//vZeRwsWwm8smKD/JXR4l/5FKQZwAeHDzeduNN668S5gqp8ayM+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/rpc": "^24.0.1",
-        "@taquito/signer": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/rpc": "^24.2.0",
+        "@taquito/signer": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "fast-json-stable-stringify": "^2.1.0"
       },
@@ -1593,14 +1594,14 @@
       }
     },
     "node_modules/@taquito/rpc": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-24.0.1.tgz",
-      "integrity": "sha512-6NRgixtZKh6w2ivsQtFkPgYzYYQCtoXyI2ph7WMKbrKERcGxzuPM12MZb1Jwx8EepOyWqDwstSH1uH3XAWdjaA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-24.2.0.tgz",
+      "integrity": "sha512-KiPO6/Sk3x+fuDnlJwgPx1K+W7QqdbbC/QdZvI1vdSnvnImlwvre3ecA1ssL15UlEjH/iFfT2B2+YM2eYcByig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/http-utils": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/http-utils": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "whatwg-url": "^15.1.0"
       },
@@ -1609,9 +1610,9 @@
       }
     },
     "node_modules/@taquito/signer": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-24.0.1.tgz",
-      "integrity": "sha512-8khsDYeI/ByatuuAbD7gIhCGLpouU5O/0wGKRuvHcwXxgXBD8EKtY/MK+5QIu8yesNdokpiQc6m4W2YUh14kng==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-24.2.0.tgz",
+      "integrity": "sha512-wInvqnAlYMIj2FUL2YYEYSE1MRvtMesL964+4ZOI7rR9ugK5ZeEYsOab2UQzLvfwsk2z63Cc1sgxwV1HCzOGfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.7",
@@ -1621,8 +1622,8 @@
         "@stablelib/nacl": "^1.0.4",
         "@stablelib/pbkdf2": "^1.0.1",
         "@stablelib/sha512": "^1.0.1",
-        "@taquito/core": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "@types/bn.js": "^5.1.5",
         "bip39": "3.1.0",
         "bn.js": "^5.2.2",
@@ -1781,20 +1782,20 @@
       }
     },
     "node_modules/@taquito/taquito": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-24.0.1.tgz",
-      "integrity": "sha512-ltGPi+n7Buws5du7bb8jHq13LKsnzfWQCyuKDg0rgXApfESkxLkYap6hZDKeKdz+95YFCMPW+gZvRfEZ847Xlw==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-24.2.0.tgz",
+      "integrity": "sha512-gHRQDEq98+HASNF5gd2yHpi8qW7IXSakmpIh1oxbj8KIE99Tgm64k1ViPSsdnT/socw4e743AQNddfPAemZCeQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/http-utils": "^24.0.1",
-        "@taquito/local-forging": "^24.0.1",
-        "@taquito/michel-codec": "^24.0.1",
-        "@taquito/michelson-encoder": "^24.0.1",
-        "@taquito/rpc": "^24.0.1",
-        "@taquito/signer": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/http-utils": "^24.2.0",
+        "@taquito/local-forging": "^24.2.0",
+        "@taquito/michel-codec": "^24.2.0",
+        "@taquito/michelson-encoder": "^24.2.0",
+        "@taquito/rpc": "^24.2.0",
+        "@taquito/signer": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "rxjs": "^7.8.2"
       },
@@ -1803,15 +1804,15 @@
       }
     },
     "node_modules/@taquito/utils": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-24.0.1.tgz",
-      "integrity": "sha512-YNRoCjps42vCMkW9oTpE7CnrvUPoSOWy7L49IAueRGcJT/pgyEZZT6BLEc2ahP+jAqFJK8lBpKV9qhL6NTbXWg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-24.2.0.tgz",
+      "integrity": "sha512-/X10WVGe7Ztx8+/FCLu5wA6zVx09Py4/wnOCo0lFJxsMKrUmBCsGeBZYb948FbX8CvLidgGy2kQTntS9wFQAsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.7",
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.3",
-        "@taquito/core": "^24.0.1",
+        "@taquito/core": "^24.2.0",
         "@types/bs58check": "^2.1.2",
         "bignumber.js": "^9.1.2",
         "blakejs": "^1.2.1",
@@ -2320,9 +2321,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -2389,13 +2390,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3272,9 +3273,9 @@
       }
     },
     "node_modules/h3": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
-      "integrity": "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.10.tgz",
+      "integrity": "sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
@@ -3543,9 +3544,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4039,24 +4040,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.4"
       }
     },
     "node_modules/readable-stream": {

--- a/create-nfts/part-3/package-lock.json
+++ b/create-nfts/part-3/package-lock.json
@@ -8,10 +8,10 @@
       "name": "create-nfts",
       "version": "0.0.0",
       "dependencies": {
-        "@airgap/beacon-types": "^4.7.0",
         "@taquito/beacon-wallet": "^24.0.1",
         "@taquito/taquito": "^24.0.1",
-        "@taquito/utils": "^24.0.1"
+        "@taquito/utils": "^24.0.1",
+        "@tezos-x/octez.connect-types": "^4.7.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
@@ -1916,6 +1916,15 @@
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^5.0.0"
+      }
+    },
+    "node_modules/@tezos-x/octez.connect-types": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@tezos-x/octez.connect-types/-/octez.connect-types-4.8.3.tgz",
+      "integrity": "sha512-/ToHY8BJTwK1XkCzJyAFn8pzXW6udV44GlTnncatsol02J3wk9JsaYB367Wmed4u4fpP7Z6KaBTlTK9DueLPRQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/chrome": "0.0.315"
       }
     },
     "node_modules/@types/bn.js": {

--- a/create-nfts/part-3/package.json
+++ b/create-nfts/part-3/package.json
@@ -17,7 +17,7 @@
     "vite-compatible-readable-stream": "^3.6.1"
   },
   "dependencies": {
-    "@airgap/beacon-types": "^4.7.0",
+    "@tezos-x/octez.connect-types": "^4.7.0",
     "@taquito/beacon-wallet": "^24.0.1",
     "@taquito/taquito": "^24.0.1",
     "@taquito/utils": "^24.0.1"

--- a/create-nfts/part-3/package.json
+++ b/create-nfts/part-3/package.json
@@ -17,9 +17,9 @@
     "vite-compatible-readable-stream": "^3.6.1"
   },
   "dependencies": {
-    "@tezos-x/octez.connect-types": "^4.7.0",
-    "@taquito/beacon-wallet": "^24.0.1",
-    "@taquito/taquito": "^24.0.1",
-    "@taquito/utils": "^24.0.1"
+    "@tezos-x/octez.connect-types": "^4.8.3",
+    "@taquito/beacon-wallet": "^24.2.0",
+    "@taquito/taquito": "^24.2.0",
+    "@taquito/utils": "^24.2.0"
   }
 }

--- a/create-nfts/part-3/src/App.svelte
+++ b/create-nfts/part-3/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { BeaconWallet } from "@taquito/beacon-wallet";
-  import { NetworkType } from "@airgap/beacon-types";
+  import { NetworkType } from "@tezos-x/octez.connect-types";
   import { TezosToolkit, MichelsonMap } from "@taquito/taquito";
   import { stringToBytes } from "@taquito/utils";
 

--- a/create-nfts/part-3/vite.config.js
+++ b/create-nfts/part-3/vite.config.js
@@ -21,9 +21,9 @@ return defineConfig({
     },
   resolve: {
     alias: {
-     "@airgap/beacon-types": path.resolve(
+     "@tezos-x/octez.connect-types": path.resolve(
        path.resolve(),
-       `./node_modules/@airgap/beacon-types/dist/${
+       `./node_modules/@tezos-x/octez.connect-types/dist/${
        isBuild ? "esm" : "cjs"
        }/index.js`
       ),

--- a/create-nfts/part-5/package-lock.json
+++ b/create-nfts/part-5/package-lock.json
@@ -8,10 +8,10 @@
       "name": "create-nfts",
       "version": "0.0.0",
       "dependencies": {
-        "@taquito/beacon-wallet": "^24.0.1",
-        "@taquito/taquito": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
-        "@tezos-x/octez.connect-types": "^4.7.0"
+        "@taquito/beacon-wallet": "^24.2.0",
+        "@taquito/taquito": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
+        "@tezos-x/octez.connect-types": "^4.8.3"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
@@ -22,14 +22,23 @@
         "vite-compatible-readable-stream": "^3.6.1"
       }
     },
-    "node_modules/@airgap/beacon-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-4.7.0.tgz",
-      "integrity": "sha512-RyPf6KaJcVgWbzef6CvAv5PbkhuF2BDMpkToXliYU0mXibUjkbGJL0bXwEJd2l0jlsxjnlXaE/V78MXhDi8o1Q==",
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@ecadlabs/beacon-core": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-uXN+XG665fGHzbWiUp0mSxnixo+JgEFrKCC9dzTEw5utkAfnrnB2s70eN1y9420ab7D0LJb3iM6TMtNMDmmy+Q==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "@stablelib/ed25519": "^2.0.2",
         "@stablelib/nacl": "^2.0.1",
         "@stablelib/utf8": "^2.0.1",
@@ -38,84 +47,84 @@
         "bs58check": "4.0.0"
       }
     },
-    "node_modules/@airgap/beacon-dapp": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-4.7.0.tgz",
-      "integrity": "sha512-tXMDrvzAg3kXPF3p2FpwzHgnIheG8Ce9CJgZsMD8piY9YTxELrZp1V2nStnX/bwTrhqHsszKn+knJdLv6+PvKw==",
+    "node_modules/@ecadlabs/beacon-dapp": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-KKKu5YQmUzijJAJiVMmHik5mDRBwWkomsOstSkasDUQqIjStg2j2szN4v3CBRDeGihSu9OOICv390+qaen/iEg==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-transport-matrix": "4.7.0",
-        "@airgap/beacon-transport-postmessage": "4.7.0",
-        "@airgap/beacon-transport-walletconnect": "4.7.0",
-        "@airgap/beacon-ui": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-ui": "4.8.1-ecad.2",
         "broadcast-channel": "^7.1.0"
       }
     },
-    "node_modules/@airgap/beacon-transport-matrix": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-4.7.0.tgz",
-      "integrity": "sha512-22o6bluMwePg+ekQD10HD9LNikAiMv3UNzouzlj4mFZgRn7BVFSyuwMQvFQ6JnsG8H7zvNT2+hlwrYfGLpaSbw==",
+    "node_modules/@ecadlabs/beacon-transport-matrix": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-deztRLczTYx+pHJrSH+G1HtrjJdAOLww7tIyq0IA+OIhTqf5oa4DwA9ULYaeXTqIXVXWmfuUL64mBY/vgEDYqQ==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "axios": "^1.8.4"
       }
     },
-    "node_modules/@airgap/beacon-transport-postmessage": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-4.7.0.tgz",
-      "integrity": "sha512-3+qLeeBEmIm74XcG6xYnxnjOf4GwvLGB89DgdjUB/Qovw0hvFtMsxomh/U52q5b4vb/fr8Rd4EmC1BGYFL9cNQ==",
+    "node_modules/@ecadlabs/beacon-transport-postmessage": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-HjJiYTy+c2AieNXpNRoHqlmqiDGnmEtErecKNZVl6ahaKwKUi3kAtb84S55h4GJv+X8Lez0iFRP7lTtO4P3Fvw==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0"
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2"
       }
     },
-    "node_modules/@airgap/beacon-transport-walletconnect": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.7.0.tgz",
-      "integrity": "sha512-mwfnQ+rplc9f0I0z2x86tPA2gLgTc17Sc+xP9vTsR0niExntH9K7+U4QxPCgGav/plnA5ubzi/owLE+FaBEs4Q==",
+    "node_modules/@ecadlabs/beacon-transport-walletconnect": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-5FoAqWlSkQBD07EMPFj2oqFoYHCoOIgHqRewNOPwrseJQzPk+gV+2tmczOfco10IF/h73ildLVZ7NeBifhM3fw==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "@walletconnect/sign-client": "2.18.0",
         "elliptic": "^6.6.1"
       }
     },
-    "node_modules/@airgap/beacon-types": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-4.7.0.tgz",
-      "integrity": "sha512-J6z+WBnJhTL8HVyW3cXL3LCOIcxo/rzBPSufsvIITuUTfgCnQE4CR6p1TIyJmaXbolorug/7jtobMyTIXUK04g==",
+    "node_modules/@ecadlabs/beacon-types": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-dmONM1TOQQ11ZWQEtmDSgXC428O7CC4ayZQWR8h/oA+bSY7mdcMZU+yijEEuk0SL7w97q7OMcLkCYgwCtsCe+w==",
       "license": "ISC",
       "dependencies": {
         "@types/chrome": "0.0.315"
       }
     },
-    "node_modules/@airgap/beacon-ui": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-4.7.0.tgz",
-      "integrity": "sha512-6R5teYH6oEGxNSNjs+HfFWryUxqoeajHJ+l55FSXYCzQlKBUpqz2cG7ZIzsr83N1bvARc4RJ8j2FLutYvCYttA==",
+    "node_modules/@ecadlabs/beacon-ui": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-K3W2mDkAswBz8SnYEi4tnzlQE79v0TZvntmq/zVaHbskYPIF0QKx+v62qgSOy3TmRK0upqLwyJ2lhu4A6VnbMA==",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "4.7.0",
-        "@airgap/beacon-transport-postmessage": "4.7.0",
-        "@airgap/beacon-types": "4.7.0",
-        "@airgap/beacon-utils": "4.7.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
         "@walletconnect/utils": "2.18.0",
         "qrcode-svg": "^1.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       }
     },
-    "node_modules/@airgap/beacon-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-4.7.0.tgz",
-      "integrity": "sha512-QIE927Q55yuPVXoKfoabPJm2/lpbgSHAaXPpvjjyfeEnXbs5hMsTVo5AyMkQFEBRalL1UIchpPB2/+iJ5YisEg==",
+    "node_modules/@ecadlabs/beacon-utils": {
+      "version": "4.8.1-ecad.2",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.2.tgz",
+      "integrity": "sha512-SyO3O8+XY8B3JHa6E8+erihScz0jFwsdXlwSACdxBmODuW7HCo/b9AgOcelaXi1s/6qTsjk5/2q56FYOMYmgHQ==",
       "license": "ISC",
       "dependencies": {
         "@stablelib/ed25519": "^2.0.2",
@@ -123,15 +132,6 @@
         "@stablelib/random": "^2.0.1",
         "@stablelib/utf8": "^2.0.1",
         "bs58check": "4.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/@stablelib/utf8": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-2.0.1.tgz",
-      "integrity": "sha512-7+C2Iap42fbLyoKMaEIIDSb1TrcQVo+lGDItYAwb2JoAJr7QffyuDnbtvV/qzTyokOIMBrJgT+Rpsp1bPR8SjA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-2.1.0.tgz",
+      "integrity": "sha512-peZgjgrPYOvjbJcVp91yYQLocr/qw5zcLsQBL+vH3D/d0IS+Cvcsbvlu+LLEcG8sVbkWMxr0ZABhY/0t3JMh0w==",
       "license": "MIT"
     },
     "node_modules/@stablelib/wipe": {
@@ -1507,14 +1507,15 @@
       }
     },
     "node_modules/@taquito/beacon-wallet": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-24.0.1.tgz",
-      "integrity": "sha512-4Of+A0ZF4jyrjSI7RWItBH6crhaowN1WWuAEHT535bNrn5Pj+dHVEhYl4T3XMhvmjOurStkdnG+TV8h9gDe1Zg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-24.2.0.tgz",
+      "integrity": "sha512-s9nCv30nUY/3Af+UFSu2vdNIhNIY+dwRvzZIH3X/k1oI4Jo2P3rRWiPyvSWKQs+eaCxHe37QsZsLEZgDmAByng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@airgap/beacon-dapp": "^4.6.4",
-        "@taquito/core": "^24.0.1",
-        "@taquito/taquito": "^24.0.1",
+        "@ecadlabs/beacon-dapp": "^4.8.1-ecad",
+        "@ecadlabs/beacon-types": "^4.8.1-ecad",
+        "@taquito/core": "^24.2.0",
+        "@taquito/taquito": "^24.2.0",
         "crypto-browserify": "^3.12.1",
         "util": "^0.12.5"
       },
@@ -1523,9 +1524,9 @@
       }
     },
     "node_modules/@taquito/core": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/core/-/core-24.0.1.tgz",
-      "integrity": "sha512-WnfWOmwOJ1KNkdGYa6DenVzSOVfmv7kHUiF+9Z9VtxmxOTPJf9mX/iBSmIeCuSJsOIkXJkswox5CTvrsnfXDcw==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/core/-/core-24.2.0.tgz",
+      "integrity": "sha512-Yo+lWWn1NrSawDDoRwgumnSTto8y9Z4EBz9pbURdl+KczGSwyEDXLTR6m7jQ1Hh1XhRYScadlyDr+AH95CdMeA==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-stringify-safe": "^5.0.1"
@@ -1535,12 +1536,12 @@
       }
     },
     "node_modules/@taquito/http-utils": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-24.0.1.tgz",
-      "integrity": "sha512-oNyxXtuonKKCnYy/eT9uzjN46i1KbsI2iJB+nf6FFGb4lJFHrXDiL1Tg1aITpv5Jy/aQmuCveh7fBFkfS4ekhQ==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-24.2.0.tgz",
+      "integrity": "sha512-+QXvH4BQxwvBNO0jPL4viICfH8YlJlsWVnBl7H5IFXiH9CxypXWgi4LS+awsZYCBf2yqJ/5irT4yS1KtnYjR3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
+        "@taquito/core": "^24.2.0",
         "node-fetch": "^2.7.0"
       },
       "engines": {
@@ -1548,13 +1549,13 @@
       }
     },
     "node_modules/@taquito/local-forging": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-24.0.1.tgz",
-      "integrity": "sha512-GY+584pVcohF9kFHqA+grX8/b8fYbMcyaXiCA/QLA0HJSImeDX3U/tOvZhAmAZhn1X6OcThHvC2PrTtqCrsvgA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-24.2.0.tgz",
+      "integrity": "sha512-BHwFpbiTvLg+qsDSLaFvLHlqokf2HGpFb/No85RcYvzuDAK7cSxJFpRdnn1U/GFIo8eXUAd2Rlo1VlStrS1rxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "fast-text-encoding": "^1.0.6",
         "whatwg-url": "^15.1.0"
@@ -1564,27 +1565,27 @@
       }
     },
     "node_modules/@taquito/michel-codec": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-24.0.1.tgz",
-      "integrity": "sha512-iPw2qQL+i8xWu1t843ztejMPHO3nJ4mY7LOBuoaSfelfGyjl5SQjYHxwI0DS3ph/KhXlfm95HcYwEILRqGhisg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-24.2.0.tgz",
+      "integrity": "sha512-+pTGzEHjWY21ybcUF9qutnYedjqJGqr5vuxpnTeajrNiWymHDHOb0vSlhwVrEPcGZTydMxN7Kth6zRDxwqxW8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1"
+        "@taquito/core": "^24.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@taquito/michelson-encoder": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-24.0.1.tgz",
-      "integrity": "sha512-c5hkyZegUo9l74Iia38oxumO8Oh3zbWZz2Bjvx0529N3bDeXu76EXeVwViNL8v/Ug7RVtGj07tvcUmFyErmQ9g==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-24.2.0.tgz",
+      "integrity": "sha512-6/gViqi5HEx89BHvo9hxiZvrIbA4gnRlg//vZeRwsWwm8smKD/JXR4l/5FKQZwAeHDzeduNN668S5gqp8ayM+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/rpc": "^24.0.1",
-        "@taquito/signer": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/rpc": "^24.2.0",
+        "@taquito/signer": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "fast-json-stable-stringify": "^2.1.0"
       },
@@ -1593,14 +1594,14 @@
       }
     },
     "node_modules/@taquito/rpc": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-24.0.1.tgz",
-      "integrity": "sha512-6NRgixtZKh6w2ivsQtFkPgYzYYQCtoXyI2ph7WMKbrKERcGxzuPM12MZb1Jwx8EepOyWqDwstSH1uH3XAWdjaA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-24.2.0.tgz",
+      "integrity": "sha512-KiPO6/Sk3x+fuDnlJwgPx1K+W7QqdbbC/QdZvI1vdSnvnImlwvre3ecA1ssL15UlEjH/iFfT2B2+YM2eYcByig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/http-utils": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/http-utils": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "whatwg-url": "^15.1.0"
       },
@@ -1609,9 +1610,9 @@
       }
     },
     "node_modules/@taquito/signer": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-24.0.1.tgz",
-      "integrity": "sha512-8khsDYeI/ByatuuAbD7gIhCGLpouU5O/0wGKRuvHcwXxgXBD8EKtY/MK+5QIu8yesNdokpiQc6m4W2YUh14kng==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-24.2.0.tgz",
+      "integrity": "sha512-wInvqnAlYMIj2FUL2YYEYSE1MRvtMesL964+4ZOI7rR9ugK5ZeEYsOab2UQzLvfwsk2z63Cc1sgxwV1HCzOGfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.7",
@@ -1621,8 +1622,8 @@
         "@stablelib/nacl": "^1.0.4",
         "@stablelib/pbkdf2": "^1.0.1",
         "@stablelib/sha512": "^1.0.1",
-        "@taquito/core": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "@types/bn.js": "^5.1.5",
         "bip39": "3.1.0",
         "bn.js": "^5.2.2",
@@ -1781,20 +1782,20 @@
       }
     },
     "node_modules/@taquito/taquito": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-24.0.1.tgz",
-      "integrity": "sha512-ltGPi+n7Buws5du7bb8jHq13LKsnzfWQCyuKDg0rgXApfESkxLkYap6hZDKeKdz+95YFCMPW+gZvRfEZ847Xlw==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-24.2.0.tgz",
+      "integrity": "sha512-gHRQDEq98+HASNF5gd2yHpi8qW7IXSakmpIh1oxbj8KIE99Tgm64k1ViPSsdnT/socw4e743AQNddfPAemZCeQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^24.0.1",
-        "@taquito/http-utils": "^24.0.1",
-        "@taquito/local-forging": "^24.0.1",
-        "@taquito/michel-codec": "^24.0.1",
-        "@taquito/michelson-encoder": "^24.0.1",
-        "@taquito/rpc": "^24.0.1",
-        "@taquito/signer": "^24.0.1",
-        "@taquito/utils": "^24.0.1",
+        "@taquito/core": "^24.2.0",
+        "@taquito/http-utils": "^24.2.0",
+        "@taquito/local-forging": "^24.2.0",
+        "@taquito/michel-codec": "^24.2.0",
+        "@taquito/michelson-encoder": "^24.2.0",
+        "@taquito/rpc": "^24.2.0",
+        "@taquito/signer": "^24.2.0",
+        "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
         "rxjs": "^7.8.2"
       },
@@ -1803,15 +1804,15 @@
       }
     },
     "node_modules/@taquito/utils": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-24.0.1.tgz",
-      "integrity": "sha512-YNRoCjps42vCMkW9oTpE7CnrvUPoSOWy7L49IAueRGcJT/pgyEZZT6BLEc2ahP+jAqFJK8lBpKV9qhL6NTbXWg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-24.2.0.tgz",
+      "integrity": "sha512-/X10WVGe7Ztx8+/FCLu5wA6zVx09Py4/wnOCo0lFJxsMKrUmBCsGeBZYb948FbX8CvLidgGy2kQTntS9wFQAsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.7",
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.3",
-        "@taquito/core": "^24.0.1",
+        "@taquito/core": "^24.2.0",
         "@types/bs58check": "^2.1.2",
         "bignumber.js": "^9.1.2",
         "blakejs": "^1.2.1",
@@ -2320,9 +2321,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -2389,13 +2390,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3272,9 +3273,9 @@
       }
     },
     "node_modules/h3": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
-      "integrity": "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.10.tgz",
+      "integrity": "sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
@@ -3543,9 +3544,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4039,24 +4040,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.4"
       }
     },
     "node_modules/readable-stream": {

--- a/create-nfts/part-5/package-lock.json
+++ b/create-nfts/part-5/package-lock.json
@@ -8,10 +8,10 @@
       "name": "create-nfts",
       "version": "0.0.0",
       "dependencies": {
-        "@airgap/beacon-types": "^4.7.0",
         "@taquito/beacon-wallet": "^24.0.1",
         "@taquito/taquito": "^24.0.1",
-        "@taquito/utils": "^24.0.1"
+        "@taquito/utils": "^24.0.1",
+        "@tezos-x/octez.connect-types": "^4.7.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
@@ -1916,6 +1916,15 @@
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^5.0.0"
+      }
+    },
+    "node_modules/@tezos-x/octez.connect-types": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@tezos-x/octez.connect-types/-/octez.connect-types-4.8.3.tgz",
+      "integrity": "sha512-/ToHY8BJTwK1XkCzJyAFn8pzXW6udV44GlTnncatsol02J3wk9JsaYB367Wmed4u4fpP7Z6KaBTlTK9DueLPRQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/chrome": "0.0.315"
       }
     },
     "node_modules/@types/bn.js": {

--- a/create-nfts/part-5/package.json
+++ b/create-nfts/part-5/package.json
@@ -17,7 +17,7 @@
     "vite-compatible-readable-stream": "^3.6.1"
   },
   "dependencies": {
-    "@airgap/beacon-types": "^4.7.0",
+    "@tezos-x/octez.connect-types": "^4.7.0",
     "@taquito/beacon-wallet": "^24.0.1",
     "@taquito/taquito": "^24.0.1",
     "@taquito/utils": "^24.0.1"

--- a/create-nfts/part-5/package.json
+++ b/create-nfts/part-5/package.json
@@ -17,9 +17,9 @@
     "vite-compatible-readable-stream": "^3.6.1"
   },
   "dependencies": {
-    "@tezos-x/octez.connect-types": "^4.7.0",
-    "@taquito/beacon-wallet": "^24.0.1",
-    "@taquito/taquito": "^24.0.1",
-    "@taquito/utils": "^24.0.1"
+    "@tezos-x/octez.connect-types": "^4.8.3",
+    "@taquito/beacon-wallet": "^24.2.0",
+    "@taquito/taquito": "^24.2.0",
+    "@taquito/utils": "^24.2.0"
   }
 }

--- a/create-nfts/part-5/src/App.svelte
+++ b/create-nfts/part-5/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { BeaconWallet } from "@taquito/beacon-wallet";
-  import { NetworkType } from "@airgap/beacon-types";
+  import { NetworkType } from "@tezos-x/octez.connect-types";
   import { TezosToolkit, MichelsonMap } from "@taquito/taquito";
   import { stringToBytes } from "@taquito/utils";
 

--- a/create-nfts/part-5/vite.config.js
+++ b/create-nfts/part-5/vite.config.js
@@ -21,9 +21,9 @@ return defineConfig({
     },
   resolve: {
     alias: {
-     "@airgap/beacon-types": path.resolve(
+     "@tezos-x/octez.connect-types": path.resolve(
        path.resolve(),
-       `./node_modules/@airgap/beacon-types/dist/${
+       `./node_modules/@tezos-x/octez.connect-types/dist/${
        isBuild ? "esm" : "cjs"
        }/index.js`
       ),


### PR DESCRIPTION
#34 removed some trailing dependencies to the Beacon packages but forgot to update the package.json file.
This PR fixes that oversight.

It also migrates the create-nfts tutorials and updates its package.json files.